### PR TITLE
Overrides bootstrap media object to wrap

### DIFF
--- a/templates/main/base.html
+++ b/templates/main/base.html
@@ -21,9 +21,16 @@
                    width: 100%;
                    text-align: center;
                 }
+                .media {
+                  display: block;
+                  padding: 1em;
+                }
+                .media > img {
+                  float: left;
+                }
         </style>
     </head>
-  
+
     <body>
 
                     <div class="page-header">
@@ -40,20 +47,20 @@
                                     {% endif %}
                                     <span class="navbar-text">
                                         <a href="{% url 'post_new' %}" >
-                                        <button class="btn btn-outline-light" type="submit"> 
+                                        <button class="btn btn-outline-light" type="submit">
                                             Share your experience
-                                        </button></a>                                            
+                                        </button></a>
                                     </span>
-                                    
+
                                   </nav>
                     </div>
-                    
+
                     <div class="content container">
-                       
-                           
+
+
                             {% block content %}
                             {% endblock %}
-                          
+
                     </div>
                     <br><br>
                     <div class="fixed-bottom">       <footer>
@@ -62,5 +69,5 @@
     </div>
         <br>
     </body>
-   
+
 </html>


### PR DESCRIPTION
Hi @arjunsoota 👋 ! A few small notes:

- Bootstrap 4.3 actually [defines the Media Object](https://getbootstrap.com/docs/4.3/components/media-object/) as:
   >  "components where some media is positioned alongside content that doesn’t wrap around said media"

   I think I understand what you are trying to accomplish, so I think it is appropriate to locally override the CSS that bootstrap is using to achieve your desired result.
- I am not a python developer (I prefer Ruby and Rails over Django), so I did not actually run this code locally, but this issue seems to be confined to adjusting Bootstrap and CSS, so I feel confident in the solution without seeing it locally in your project.
- Because I was unable to run the solution locally, [I made a codepen to demonstrate the changes](https://codepen.io/maskott/pen/vYYENyX?editors=1100).
- My actual solution is only the 7 new lines of CSS, but my IDE would not let me save without cleaning up some whitespace issues in the `base.html` file.

Thanks, and happy Hacktoberfest!